### PR TITLE
add support for win32

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,15 +7,17 @@ set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${PROJECT_SOURCE_DIR})
 enable_language(CXX)
 
 find_package(kodi REQUIRED)
+find_package(kodiplatform REQUIRED)
 
-include_directories(${KODI_INCLUDE_DIR}
+include_directories(${kodiplatform_INCLUDE_DIRS}
+                    ${KODI_INCLUDE_DIR}
                     ${PROJECT_SOURCE_DIR}/lib/vgmstream)
 
 add_subdirectory(lib/vgmstream)
 
 set(VGM_SOURCES src/VGMCodec.cpp)
 
-set(DEPLIBS vgmstream)
+set(DEPLIBS ${kodiplatform_LIBRARIES} vgmstream)
 
 build_addon(audiodecoder.vgmstream VGM DEPLIBS)
 

--- a/audiodecoder.vgmstream/addon.xml
+++ b/audiodecoder.vgmstream/addon.xml
@@ -11,7 +11,11 @@
     point="kodi.audiodecoder"
     name="vgm"
     extension=".aax|.acm|.adp|.ads|.adx|.afc|.agsc|.ahx|.aifc|.aix|.amts|.as4|.asd|.asf|.asr|.ass|.ast|.aud|.aus|.bg00|.bgw|.bh2pcm|.bmdx|.brstm|.capdsp|.ccc|.cfn|.cnk|.dcs|.de2|.dsp|.dvi|.dxh|.eam|.emff|.enth|.fag|.filp|.fsb|.gbts|.gca|.gcm|.gcw|.genh|.gms|.gsb|.hgc1|.hps|.idsp|.idvi|.ikm|.ild|.int|.isd|.ivb|.joe|.kces|.kcey|.kraw|.leg|.logg|.lwav|.matx|.mi4|.mib|.mic|.mihb|.mpdsp|.mss|.msvp|.mus|.musc|.musx|.mwv|.npsf|.nwa|.omu|.p2bt|.pcm|.pdt|.pnb|.pos|.psh|.pws|.raw|.rkv|.rnd|.rsd|.rsf|.rstm|.rwsd|.rwav|.rws|.rwx|.rxw|.sad|.sdt|.seg|.sfl|.sfs|.sl3|.sli|.smp|.sng|.spd|.spsd|.spw|.ss2|.ss7|.ssm|.stma|.str|.strm|.sts|.svag|.svs|.swd|.tec|.thp|.tydsp|.um3|.vag|.vas|.vgs|.vig|.vpk|.vs|.waa|.wac|.wad|.wam|.wavm|.wp2|.wsi|.wvs|.xa|.xa2|.xa30|.xmu|.xsp|.xss|.xvas|.xwav|.xwb|.ydsp|.ymf|.zwdsp"
-    library_linux="audiodecoder.vgmstream.so"/>
+    library_linux="audiodecoder.vgmstream.so"
+    library_osx="audiodecoder.vgmstream.dylib"
+    library_freebsd="audiodecoder.vgmstream.so"
+    library_windx="audiodecoder.vgmstream.dll"
+    library_android="libaudiodecoder.vgmstream.so"/>
   <extension point="xbmc.addon.metadata">
     <summary lang="en">VGM Audio Decoder</summary>
     <description lang="en">Video Game Music Audio Decoder</description>

--- a/lib/vgmstream/src/streamtypes.h
+++ b/lib/vgmstream/src/streamtypes.h
@@ -6,13 +6,12 @@
 #ifndef _STREAMTYPES_H
 #define _STREAMTYPES_H
 
+#include <stdint.h>
 #ifdef _MSC_VER
-#include <pstdint.h>
+//#include <pstdint.h>
 #define inline _inline
 #define strcasecmp _stricmp
 #define snprintf _snprintf
-#else
-#include <stdint.h>
 #endif
 
 typedef int16_t sample;

--- a/lib/vgmstream/src/vgmstream.h
+++ b/lib/vgmstream/src/vgmstream.h
@@ -10,8 +10,8 @@
  * If someone wants to do a standalone build, they can do it by simply
  * removing these defines (and the references to the libraries in the
  * Makefile) */
-#define VGM_USE_VORBIS
-#define VGM_USE_MPEG
+//#define VGM_USE_VORBIS
+//#define VGM_USE_MPEG
 /* disabled by default, defined for builds that support it */
 //#define VGM_USE_G7221
 


### PR DESCRIPTION
These commits make the addon build for win32 (haven't runtime tested it).
The first commit disables support of and dependencies on Vorbis and MPEG.
The last commit adds all the missing library definitions to `addon.xml`.