### PR TITLE
Header include math.h

### DIFF
--- a/lib/vgmstream/src/meta/ubi_sb.c
+++ b/lib/vgmstream/src/meta/ubi_sb.c
@@ -2,6 +2,7 @@
 #include "../layout/layout.h"
 #include "../coding/coding.h"
 #include "ubi_sb_streamfile.h"
+#include <math.h>
 
 
 #define SB_MAX_LAYER_COUNT 16  /* arbitrary max */


### PR DESCRIPTION
Fixes build error

```
 /Users/Shared/jenkins/workspace/TVOS/tools/depends/target/binary-addons/appletvos13.2_arm64-target-release/build/audiodecoder.vgmstream/lib/vgmstream/src/meta/ubi_sb.c:1754:22: error: implicitly declaring library function 'ceil' with type 'double (double)' [-Werror,-Wimplicit-function-declaration]
     return (uint32_t)ceil(sample_rate);
                                 ^
```

Will look to upstream